### PR TITLE
Fix Dupe Data, Tracking Pixel

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -12,7 +12,8 @@ return [
                 'class'     => \MauticPlugin\MauticAdvancedTemplatesBundle\EventListener\EmailSubscriber::class,
                 'arguments' => [
                     'monolog.logger.mautic',
-                    'mautic.plugin.advanced_templates.helper.template_processor'
+                    'mautic.plugin.advanced_templates.helper.template_processor',
+                    'mautic.email.model.email'
                 ]
             ]
         ],

--- a/Config/config.php
+++ b/Config/config.php
@@ -3,7 +3,7 @@
 return [
     'name'        => 'Advanced Templates',
     'description' => 'Plugin extends default email template capabilities with TWIG block so you can use advanced scripting techniques like conditions, loops etc',
-    'version'     => '2.0',
+    'version'     => '2.1',
     'author'      => 'Dmitry Berezovsky',
     'services' => [
         'events' => [

--- a/Helper/TemplateProcessor.php
+++ b/Helper/TemplateProcessor.php
@@ -52,7 +52,6 @@ class TemplateProcessor
         $this->feedFactory = $feedFactory;
     }
 
-
     /**
      * @param string $content
      * @param array $lead


### PR DESCRIPTION
This PR:

* Fixes the tracking pixel, it was disabled due to https://github.com/icecubenz/mautic-advanced-templates-bundle/blob/master/EventListener/EmailSubscriber.php#L73.

https://github.com/mautic/mautic/blob/4.0/app/bundles/EmailBundle/Event/EmailSendEvent.php#L200 if there is a MailHelper (which we want because it does helpful things) calls `setBody` and disables the tracking pixel. This method works around that. MailHelper `setBody` is preferred as it appends the tracking pixel, so I've worked to get that to be the method uses (while still handling the case there is no mail helper e.g. preview and webview) 

* Refactors the plaintext content so that it's regenerated (only if not statically set).

* In every case pull subject, plaintext and customHtml content off the `Email` entity, so that we avoid duplicated content and edge cases. Set via the `EmailSendEvent` (and hopefully the `MailHelper`)

* This technique also avoids duplicate content in the webview

As a result each email, webview should have the correct content for the contact emailed and tracking pixels applied automatically to the emails. 